### PR TITLE
fix: Exception in `JsonElementValidator`

### DIFF
--- a/Source/aweXpect.Json/Json/JsonElementValidator.cs
+++ b/Source/aweXpect.Json/Json/JsonElementValidator.cs
@@ -271,6 +271,11 @@ internal static class JsonElementValidator
 					Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get();
 				foreach (KeyValuePair<string, string> differentMember in _errors)
 				{
+					if (sb.Length > 0)
+					{
+						sb.Append(" and");
+					}
+					
 					if (count++ >= maximumNumberOfCollectionItems)
 					{
 						sb.AppendLine().Append("   … (")
@@ -284,11 +289,9 @@ internal static class JsonElementValidator
 						sb.AppendLine().Append(' ');
 					}
 
-					sb.Append(' ').Append(differentMember.Key).Append(' ').Append(differentMember.Value).Append(" and");
+					sb.Append(' ').Append(differentMember.Key).Append(' ').Append(differentMember.Value);
 				}
 			}
-
-			sb.Length -= 4;
 
 			return sb.ToString();
 		}

--- a/Tests/aweXpect.Json.Tests/CustomizeJsonTests.cs
+++ b/Tests/aweXpect.Json.Tests/CustomizeJsonTests.cs
@@ -1,8 +1,7 @@
 ﻿using System.Text.Json;
 using aweXpect.Customization;
-using aweXpect.Json;
 
-namespace aweXpect.Internal.Tests.Json;
+namespace aweXpect.Json.Tests;
 
 public sealed class CustomizeJsonTests
 {

--- a/Tests/aweXpect.Json.Tests/JsonOptionsTests.cs
+++ b/Tests/aweXpect.Json.Tests/JsonOptionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
-using aweXpect.Json;
 
-namespace aweXpect.Core.Tests.Options;
+namespace aweXpect.Json.Tests;
 
 public class JsonOptionsTests
 {

--- a/Tests/aweXpect.Json.Tests/StringEqualityOptionsTests.cs
+++ b/Tests/aweXpect.Json.Tests/StringEqualityOptionsTests.cs
@@ -1,0 +1,24 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Json.Tests;
+
+public sealed class StringEqualityOptionsTests
+{
+	[Fact]
+	public async Task EqualJson_ShouldReturnEmptyFailure()
+	{
+		string actual = "{}";
+		string expected = "{  }";
+#pragma warning disable aweXpect0001
+		IOptionsProvider<StringEqualityOptions> optionsProvider = That(actual).IsEqualTo(expected).AsJson();
+#pragma warning restore aweXpect0001
+
+		var result = optionsProvider.Options.AreConsideredEqual(actual, expected);
+		var failure = optionsProvider.Options.GetExtendedFailure("it", actual, expected);
+
+		await That(result).IsTrue();
+		await That(failure).IsEmpty();
+	}
+}

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.IsArray.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.IsArray.Tests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.IsObject.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.IsObject.Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
-using aweXpect.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.Matches.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.Matches.Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
-using aweXpect.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.MatchesExactly.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.MatchesExactly.Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
-using aweXpect.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.IsArray.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.IsArray.Tests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatNullableJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.IsObject.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.IsObject.Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
-using aweXpect.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatNullableJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.Matches.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.Matches.Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
-using aweXpect.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatNullableJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.MatchesExactly.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.MatchesExactly.Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
-using aweXpect.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatNullableJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatNullableJsonElement
 {

--- a/Tests/aweXpect.Json.Tests/ThatString.IsEqualTo.AsJson.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatString.IsEqualTo.AsJson.Tests.cs
@@ -1,7 +1,6 @@
 ﻿using aweXpect.Customization;
-using aweXpect.Json;
 
-namespace aweXpect.Tests;
+namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatString
 {
@@ -12,46 +11,20 @@ public sealed partial class ThatString
 			public sealed class Tests
 			{
 				[Fact]
-				public async Task WhenContainsMoreThan10Differences_ShouldLimitListOfDifferences()
+				public async Task ForCollections_ShouldSupportAsJson()
 				{
-					string subject = """
-					                 {
-					                   "foo1": null,
-					                   "foo2": null,
-					                   "foo3": null,
-					                   "foo4": null,
-					                   "foo5": null,
-					                   "foo6": null,
-					                   "foo7": null,
-					                   "foo8": null,
-					                   "foo9": null,
-					                   "foo10": null,
-					                   "foo11": null,
-					                   "foo12": null,
-					                 }
-					                 """;
+					string[] subject = ["{ }", "{foo:1}", "[]"];
 					string expected = "{}";
 
 					async Task Act()
-						=> await That(subject).IsEqualTo(expected).AsJson();
+						=> await That(subject).All().AreEqualTo(expected).AsJson();
 
 					await That(Act).Throws<XunitException>()
-						.WithMessage("""
+						.WithMessage(""""
 						             Expected that subject
-						             is JSON equivalent to {},
-						             but it differed as
-						               $.foo1 had unexpected Null and
-						               $.foo2 had unexpected Null and
-						               $.foo3 had unexpected Null and
-						               $.foo4 had unexpected Null and
-						               $.foo5 had unexpected Null and
-						               $.foo6 had unexpected Null and
-						               $.foo7 had unexpected Null and
-						               $.foo8 had unexpected Null and
-						               $.foo9 had unexpected Null and
-						               $.foo10 had unexpected Null and
-						                … (2 more)
-						             """);
+						             is equal to "{}" as JSON for all items,
+						             but only 1 of 3 were
+						             """");
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Json.Tests/ThatString.IsEqualTo.AsJson.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatString.IsEqualTo.AsJson.Tests.cs
@@ -28,6 +28,49 @@ public sealed partial class ThatString
 				}
 
 				[Fact]
+				public async Task WhenContainsMoreThan10Differences_ShouldLimitListOfDifferences()
+				{
+					string subject = """
+					                 {
+					                   "foo1": null,
+					                   "foo2": null,
+					                   "foo3": null,
+					                   "foo4": null,
+					                   "foo5": null,
+					                   "foo6": null,
+					                   "foo7": null,
+					                   "foo8": null,
+					                   "foo9": null,
+					                   "foo10": null,
+					                   "foo11": null,
+					                   "foo12": null,
+					                 }
+					                 """;
+					string expected = "{}";
+
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected).AsJson();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is JSON equivalent to {},
+						             but it differed as
+						               $.foo1 had unexpected Null and
+						               $.foo2 had unexpected Null and
+						               $.foo3 had unexpected Null and
+						               $.foo4 had unexpected Null and
+						               $.foo5 had unexpected Null and
+						               $.foo6 had unexpected Null and
+						               $.foo7 had unexpected Null and
+						               $.foo8 had unexpected Null and
+						               $.foo9 had unexpected Null and
+						               $.foo10 had unexpected Null and
+						                … (2 more)
+						             """);
+				}
+
+				[Fact]
 				public async Task
 					WhenContainsMoreThanMaximumNumberOfCollectionItemsDifferences_ShouldLimitListOfDifferences()
 				{

--- a/Tests/aweXpect.Json.Tests/ThatString.IsValidJson.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatString.IsValidJson.Tests.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect.Tests;
+﻿namespace aweXpect.Json.Tests;
 
 public sealed partial class ThatString
 {


### PR DESCRIPTION
When comparing two empty Json strings, the `JsonElementValidator` throws an exception (`IndexOutOfRangeException` in the `StringBuilder`).