### PR TITLE
revert: xunit v3 migration

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -36,6 +36,7 @@
         "CodeAnalysisEnd",
         "CodeCoverage",
         "Compile",
+        "DotNetFrameworkUnitTests",
         "DotNetUnitTests",
         "MutationComment",
         "MutationTestExecution",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,10 @@
 	<ItemGroup>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
 		<PackageVersion Include="BenchmarkDotNet" Version="0.14.0"/>
-		<PackageVersion Include="xunit.v3" Version="1.1.0"/>
+		<PackageVersion Include="NUnit" Version="4.3.2"/>
+		<PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
+		<PackageVersion Include="NUnit.Analyzers" Version="4.6.0"/>
+		<PackageVersion Include="xunit" Version="2.9.3"/>
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.4"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.4.2"/>

--- a/Pipeline/Build.UnitTest.cs
+++ b/Pipeline/Build.UnitTest.cs
@@ -1,8 +1,11 @@
 using System.Linq;
 using Nuke.Common;
+using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.Xunit;
+using static Nuke.Common.Tools.Xunit.XunitTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 // ReSharper disable AllUnderscoreLocalParameterName
@@ -12,6 +15,7 @@ namespace Build;
 partial class Build
 {
 	Target UnitTests => _ => _
+		.DependsOn(DotNetFrameworkUnitTests)
 		.DependsOn(DotNetUnitTests);
 
 	Project[] UnitTestProjects =>
@@ -19,15 +23,33 @@ partial class Build
 		Solution.Tests.aweXpect_Json_Tests,
 	];
 
+	Target DotNetFrameworkUnitTests => _ => _
+		.Unlisted()
+		.DependsOn(Compile)
+		.OnlyWhenDynamic(() => EnvironmentInfo.IsWin)
+		.Executes(() =>
+		{
+			string[] testAssemblies = UnitTestProjects
+				.SelectMany(project =>
+					project.Directory.GlobFiles(
+						$"bin/{(Configuration == Configuration.Debug ? "Debug" : "Release")}/net48/*.Tests.dll"))
+				.Select(p => p.ToString())
+				.ToArray();
+
+			Assert.NotEmpty(testAssemblies.ToList());
+
+			Xunit2(s => s
+				.SetFramework("net48")
+				.AddTargetAssemblies(testAssemblies)
+			);
+		});
+
 	Target DotNetUnitTests => _ => _
 		.Unlisted()
 		.DependsOn(Compile)
 		.Executes(() =>
 		{
-			string[] excludedFrameworks =
-				EnvironmentInfo.IsWin
-					? []
-					: ["net48"];
+			string[] excludedFrameworks = ["net48",];
 			DotNetTest(s => s
 					.SetConfiguration(Configuration)
 					.SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -8,7 +8,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<OutputType>exe</OutputType>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -19,7 +18,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit.v3"/>
+		<PackageReference Include="xunit"/>
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/Tests/aweXpect.Json.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Json.Api.Tests/ApiAcceptance.cs
@@ -5,7 +5,8 @@ public sealed class ApiAcceptance
 	/// <summary>
 	///     Execute this test to update the expected public API to the current API surface.
 	/// </summary>
-	[Fact(Explicit = true)]
+	[TestCase]
+	[Explicit]
 	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =

--- a/Tests/aweXpect.Json.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Json.Api.Tests/ApiApprovalTests.cs
@@ -1,4 +1,7 @@
-﻿namespace aweXpect.Api.Tests;
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace aweXpect.Api.Tests;
 
 /// <summary>
 ///     Whenever a test fails, this means that the public API surface changed.
@@ -7,8 +10,7 @@
 /// </summary>
 public sealed class ApiApprovalTests
 {
-	[Theory]
-	[MemberData(nameof(TargetFrameworksTheoryData))]
+	[TestCaseSource(nameof(TargetFrameworksTheoryData))]
 	public async Task VerifyPublicApiForAweXpectJson(string framework)
 	{
 		const string assemblyName = "aweXpect.Json";
@@ -19,9 +21,9 @@ public sealed class ApiApprovalTests
 		await That(publicApi).IsEqualTo(expectedApi);
 	}
 
-	public static TheoryData<string> TargetFrameworksTheoryData()
+	public static IEnumerable TargetFrameworksTheoryData()
 	{
-		TheoryData<string> theoryData = new();
+		List<string> theoryData = new();
 		foreach (string targetFramework in Helper.GetTargetFrameworks())
 		{
 			theoryData.Add(targetFramework);

--- a/Tests/aweXpect.Json.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Json.Api.Tests/ApiApprovalTests.cs
@@ -21,7 +21,7 @@ public sealed class ApiApprovalTests
 		await That(publicApi).IsEqualTo(expectedApi);
 	}
 
-	public static IEnumerable TargetFrameworksTheoryData()
+	private static IEnumerable TargetFrameworksTheoryData()
 	{
 		List<string> theoryData = new();
 		foreach (string targetFramework in Helper.GetTargetFrameworks())

--- a/Tests/aweXpect.Json.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Json.Api.Tests/ApiApprovalTests.cs
@@ -21,7 +21,7 @@ public sealed class ApiApprovalTests
 		await That(publicApi).IsEqualTo(expectedApi);
 	}
 
-	private static IEnumerable TargetFrameworksTheoryData()
+	private static List<string> TargetFrameworksTheoryData()
 	{
 		List<string> theoryData = new();
 		foreach (string targetFramework in Helper.GetTargetFrameworks())

--- a/Tests/aweXpect.Json.Api.Tests/Usings.cs
+++ b/Tests/aweXpect.Json.Api.Tests/Usings.cs
@@ -1,5 +1,5 @@
 ﻿global using System;
 global using System.Threading.Tasks;
-global using Xunit;
+global using NUnit.Framework;
 global using aweXpect;
 global using static aweXpect.Expect;

--- a/Tests/aweXpect.Json.Api.Tests/aweXpect.Json.Api.Tests.csproj
+++ b/Tests/aweXpect.Json.Api.Tests/aweXpect.Json.Api.Tests.csproj
@@ -9,6 +9,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Remove="xunit"/>
+		<PackageReference Remove="xunit.runner.visualstudio"/>
+		<PackageReference Include="NUnit"/>
+		<PackageReference Include="NUnit.Analyzers"/>
+		<PackageReference Include="NUnit3TestAdapter"/>
 		<PackageReference Include="PublicApiGenerator"/>
 	</ItemGroup>
 


### PR DESCRIPTION
Revert back the xunit v3 migration, as [Stryker.NET doesn't handle xUnit v3 properly](https://github.com/stryker-mutator/stryker-net/issues/3117).