### PR TITLE
feat: add `IsJsonSerializable`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="1.5.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="1.5.0"/>
+		<PackageVersion Include="aweXpect" Version="1.6.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="1.6.0"/>
 		<PackageVersion Include="System.Text.Json" Version="9.0.2"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -2,6 +2,30 @@
 
 Expectations for the `System.Text.Json` namespace.
 
+## Object serializable
+
+You can verify that an object is JSON serializable:
+
+```csharp
+MyObject subject = new();
+
+await Expect.That(subject).IsJsonSerializable();
+```
+
+This will try to serialize and deserialize the provided object and check that they are equivalent.
+
+You can provide both JSON serialization and equivalency options:
+
+```csharp
+MyObject subject = new();
+
+await Expect.That(subject).IsJsonSerializable(
+    new JsonSerializerOptions
+    {
+        IncludeFields = includeFields,
+    },
+    o => o.IgnoringMember("MyPropertyToIgnore"));
+```
 
 ## String comparison as JSON
 
@@ -60,7 +84,6 @@ string subject = "[{\"foo\": 2}, {\"foo\": 3}, {\"foo\": 4, \"bar\": 2}]";
 
 await Expect.That(subject).IsValidJsonMatching([ new{ foo = 2 }, new{ foo = 3 }, new{ foo = 4 } ]);
 ```
-
 
 ## `JsonElement`
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,31 @@
 
 Extensions on System.Text.Json for [aweXpect](https://github.com/aweXpect/aweXpect).
 
+## Object serializable
+
+You can verify that an object is JSON serializable:
+
+```csharp
+MyObject subject = new();
+
+await Expect.That(subject).IsJsonSerializable();
+```
+
+This will try to serialize and deserialize the provided object and check that they are equivalent.
+
+You can provide both JSON serialization and equivalency options:
+
+```csharp
+MyObject subject = new();
+
+await Expect.That(subject).IsJsonSerializable(
+    new JsonSerializerOptions
+    {
+        IncludeFields = includeFields,
+    },
+    o => o.IgnoringMember("MyPropertyToIgnore"));
+```
+
 ## String comparison as JSON
 
 You can compare two strings for JSON equivalency:

--- a/Source/aweXpect.Json/ThatJsonObject.IsJsonSerializable.cs
+++ b/Source/aweXpect.Json/ThatJsonObject.IsJsonSerializable.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Text;
+using System.Text.Json;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Equivalency;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+/// <summary>
+///     Json expectations on <see langword="object" /> values.
+/// </summary>
+public static class ThatJsonObject
+{
+	/// <summary>
+	///     Verifies that the subject can be serialized as JSON.
+	/// </summary>
+	public static AndOrResult<object?, IThat<object?>> IsJsonSerializable(
+		this IThat<object?> source,
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		=> new(
+			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
+				=> new IsJsonSerializableConstraint<object>(it, new JsonSerializerOptions(),
+					FromCallback(equivalencyOptions))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject can be serialized as JSON.
+	/// </summary>
+	public static AndOrResult<object?, IThat<object?>> IsJsonSerializable(
+		this IThat<object?> source,
+		JsonSerializerOptions serializerOptions,
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		=> new(
+			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
+				=> new IsJsonSerializableConstraint<object>(it, serializerOptions,
+					FromCallback(equivalencyOptions))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject can be serialized as JSON of type <typeparamref name="T" />.
+	/// </summary>
+	public static AndOrResult<object?, IThat<object?>> IsJsonSerializable<T>(
+		this IThat<object?> source,
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		=> new(
+			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
+				=> new IsJsonSerializableConstraint<T>(it, new JsonSerializerOptions(),
+					FromCallback(equivalencyOptions))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject can be serialized as JSON of type <typeparamref name="T" />.
+	/// </summary>
+	public static AndOrResult<object?, IThat<object?>> IsJsonSerializable<T>(
+		this IThat<object?> source,
+		JsonSerializerOptions serializerOptions,
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		=> new(
+			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
+				=> new IsJsonSerializableConstraint<T>(it, serializerOptions,
+					FromCallback(equivalencyOptions))),
+			source);
+
+	/// <summary>
+	///     Creates a new <see cref="EquivalencyOptions" /> instance from the provided <paramref name="callback" />.
+	/// </summary>
+	/// <remarks>
+	///     Uses the default instance, when no <paramref name="callback" /> is given.
+	/// </remarks>
+	private static EquivalencyOptions FromCallback(Func<EquivalencyOptions, EquivalencyOptions>? callback)
+		=> callback is null
+			? Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get()
+			: callback(Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get());
+
+	private readonly struct IsJsonSerializableConstraint<T>(
+		string it,
+		JsonSerializerOptions serializerOptions,
+		EquivalencyOptions options)
+		: IValueConstraint<object?>
+	{
+		public ConstraintResult IsMetBy(object? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<T?>(default, ToString(), $"{it} was <null>");
+			}
+
+			if (actual is not T typedSubject)
+			{
+				return new ConstraintResult.Failure<T?>(default, ToString(),
+					$"{it} was not assignable to {Formatter.Format(typeof(T))}");
+			}
+
+			object? deserializedObject;
+			try
+			{
+				string serializedObject = JsonSerializer.Serialize(actual, serializerOptions);
+				deserializedObject = JsonSerializer.Deserialize(serializedObject, actual.GetType(), serializerOptions);
+			}
+			catch (Exception e)
+			{
+				return new ConstraintResult.Failure<T?>(typedSubject, ToString(),
+					$"{it} could not be deserialized: {e.Message}");
+			}
+
+			StringBuilder failureBuilder = new();
+			if (EquivalencyComparison.Compare(deserializedObject, actual, options, failureBuilder))
+			{
+				return new ConstraintResult.Success<T?>(typedSubject, ToString());
+			}
+
+			failureBuilder.Insert(0, " was not:");
+			failureBuilder.Insert(0, it);
+			return new ConstraintResult.Failure<T?>(typedSubject, ToString(),
+				failureBuilder.ToString());
+		}
+
+		public override string ToString()
+			=> (typeof(T) == typeof(object)) switch
+			{
+				true => "is serializable as JSON",
+				false => $"is serializable as {Formatter.Format(typeof(T))} JSON",
+			};
+	}
+}

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -24,15 +24,19 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
-		<PackageReference Include="Nullable">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="aweXpect"/>
+		<PackageReference Include="Nullable">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="IsExternalInit">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 </Project>

--- a/Tests/aweXpect.Json.Api.Tests/Expected/aweXpect.Json_net8.0.txt
+++ b/Tests/aweXpect.Json.Api.Tests/Expected/aweXpect.Json_net8.0.txt
@@ -81,6 +81,13 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Text.Json.JsonElement, aweXpect.Core.IThat<System.Text.Json.JsonElement>> MatchesExactly(this aweXpect.Core.IThat<System.Text.Json.JsonElement> source, object? expected, System.Func<aweXpect.Json.JsonOptions, aweXpect.Json.JsonOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Text.Json.JsonElement, aweXpect.Core.IThat<System.Text.Json.JsonElement>> MatchesExactly<T>(this aweXpect.Core.IThat<System.Text.Json.JsonElement> source, System.Collections.Generic.IEnumerable<T> expected, System.Func<aweXpect.Json.JsonOptions, aweXpect.Json.JsonOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
     }
+    public static class ThatJsonObject
+    {
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsJsonSerializable(this aweXpect.Core.IThat<object?> source, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsJsonSerializable(this aweXpect.Core.IThat<object?> source, System.Text.Json.JsonSerializerOptions serializerOptions, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsJsonSerializable<T>(this aweXpect.Core.IThat<object?> source, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsJsonSerializable<T>(this aweXpect.Core.IThat<object?> source, System.Text.Json.JsonSerializerOptions serializerOptions, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null) { }
+    }
     public static class ThatJsonString
     {
         public static aweXpect.Results.JsonWhichResult IsValidJson(this aweXpect.Core.IThat<string?> source, System.Func<System.Text.Json.JsonDocumentOptions, System.Text.Json.JsonDocumentOptions>? options = null) { }

--- a/Tests/aweXpect.Json.Api.Tests/Expected/aweXpect.Json_netstandard2.0.txt
+++ b/Tests/aweXpect.Json.Api.Tests/Expected/aweXpect.Json_netstandard2.0.txt
@@ -81,6 +81,13 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Text.Json.JsonElement, aweXpect.Core.IThat<System.Text.Json.JsonElement>> MatchesExactly(this aweXpect.Core.IThat<System.Text.Json.JsonElement> source, object? expected, System.Func<aweXpect.Json.JsonOptions, aweXpect.Json.JsonOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Text.Json.JsonElement, aweXpect.Core.IThat<System.Text.Json.JsonElement>> MatchesExactly<T>(this aweXpect.Core.IThat<System.Text.Json.JsonElement> source, System.Collections.Generic.IEnumerable<T> expected, System.Func<aweXpect.Json.JsonOptions, aweXpect.Json.JsonOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
     }
+    public static class ThatJsonObject
+    {
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsJsonSerializable(this aweXpect.Core.IThat<object?> source, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsJsonSerializable(this aweXpect.Core.IThat<object?> source, System.Text.Json.JsonSerializerOptions serializerOptions, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsJsonSerializable<T>(this aweXpect.Core.IThat<object?> source, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsJsonSerializable<T>(this aweXpect.Core.IThat<object?> source, System.Text.Json.JsonSerializerOptions serializerOptions, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null) { }
+    }
     public static class ThatJsonString
     {
         public static aweXpect.Results.JsonWhichResult IsValidJson(this aweXpect.Core.IThat<string?> source, System.Func<System.Text.Json.JsonDocumentOptions, System.Text.Json.JsonDocumentOptions>? options = null) { }

--- a/Tests/aweXpect.Json.Tests/ThatJsonObject.IsJsonSerializable.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonObject.IsJsonSerializable.Tests.cs
@@ -1,0 +1,398 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace aweXpect.Json.Tests;
+
+public sealed class ThatJsonObject
+{
+	public sealed class IsJsonSerializable
+	{
+		public sealed class ObjectTests
+		{
+			[Fact]
+			public async Task WhenSubjectHasAnIgnoredProperty_ShouldFail()
+			{
+				PocoWithIgnoredProperty subject = new()
+				{
+					Id = 2,
+					Name = "foo",
+				};
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as JSON,
+					             but it was not:
+					               Property Name was <null> instead of "foo"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAnIgnoredProperty_WhenPropertyIsIgnored_ShouldSucceed()
+			{
+				PocoWithIgnoredProperty subject = new()
+				{
+					Id = 2,
+					Name = "foo",
+				};
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable(o => o with
+					{
+						MembersToIgnore = ["Name",],
+					});
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAPrivateConstructor_ShouldFail()
+			{
+				PocoWithPrivateConstructor subject = PocoWithPrivateConstructor.Create(42);
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as JSON,
+					             but it could not be deserialized: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'aweXpect.Json.Tests.ThatJsonObject+IsJsonSerializable+PocoWithPrivateConstructor'*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAPrivateConstructorWithJsonConstructorAttribute_ShouldSucceed()
+			{
+				PocoWithPrivateConstructorWithJsonConstructorAttribute subject =
+					PocoWithPrivateConstructorWithJsonConstructorAttribute.Create(42);
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasNoDefaultConstructor_ShouldFail()
+			{
+				PocoWithoutDefaultConstructor subject = new(12);
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as JSON,
+					             but it could not be deserialized: Each parameter in the deserialization constructor on type 'aweXpect.Json.Tests.ThatJsonObject+IsJsonSerializable+PocoWithoutDefaultConstructor' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object*
+					             """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData(true)]
+			[InlineData(false)]
+			public async Task WhenSubjectHasNoDefaultFieldConstructor_ShouldFailUnlessIncludeFieldsIsSet(
+				bool includeFields)
+			{
+				PocoWithoutDefaultFieldConstructor subject = new(12);
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable(new JsonSerializerOptions
+					{
+						IncludeFields = includeFields,
+					});
+
+				await That(Act).Throws<XunitException>().OnlyIf(!includeFields)
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as JSON,
+					             but it could not be deserialized: Each parameter in the deserialization constructor on type 'aweXpect.Json.Tests.ThatJsonObject+IsJsonSerializable+PocoWithoutDefaultFieldConstructor' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object. Fields are only considered when 'JsonSerializerOptions.IncludeFields' is enabled*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				object? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as JSON,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsPoco_ShouldSucceed()
+			{
+				SimplePocoWithPrimitiveTypes subject = new()
+				{
+					Id = 1,
+					GlobalId = Guid.NewGuid(),
+					Name = "foo",
+					DateOfBirth = DateTime.Today,
+					Height = new decimal(4.3),
+					Weight = 5.6,
+					ShoeSize = 7.8f,
+					IsActive = true,
+					Image = [8, 9, 10, 11,],
+					Category = 'a',
+				};
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task WhenSubjectHasAnIgnoredProperty_ShouldFail()
+			{
+				PocoWithIgnoredProperty subject = new()
+				{
+					Id = 2,
+					Name = "foo",
+				};
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<PocoWithIgnoredProperty>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as PocoWithIgnoredProperty JSON,
+					             but it was not:
+					               Property Name was <null> instead of "foo"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAnIgnoredProperty_WhenPropertyIsIgnored_ShouldSucceed()
+			{
+				PocoWithIgnoredProperty subject = new()
+				{
+					Id = 2,
+					Name = "foo",
+				};
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<PocoWithIgnoredProperty>(o => o with
+					{
+						MembersToIgnore = ["Name",],
+					});
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAPrivateConstructor_ShouldFail()
+			{
+				PocoWithPrivateConstructor subject = PocoWithPrivateConstructor.Create(42);
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<PocoWithPrivateConstructor>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as PocoWithPrivateConstructor JSON,
+					             but it could not be deserialized: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'aweXpect.Json.Tests.ThatJsonObject+IsJsonSerializable+PocoWithPrivateConstructor'*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAPrivateConstructorWithJsonConstructorAttribute_ShouldSucceed()
+			{
+				PocoWithPrivateConstructorWithJsonConstructorAttribute subject =
+					PocoWithPrivateConstructorWithJsonConstructorAttribute.Create(42);
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<PocoWithPrivateConstructorWithJsonConstructorAttribute>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasNoDefaultConstructor_ShouldFail()
+			{
+				PocoWithoutDefaultConstructor subject = new(12);
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<PocoWithoutDefaultConstructor>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as PocoWithoutDefaultConstructor JSON,
+					             but it could not be deserialized: Each parameter in the deserialization constructor on type 'aweXpect.Json.Tests.ThatJsonObject+IsJsonSerializable+PocoWithoutDefaultConstructor' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object*
+					             """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData(true)]
+			[InlineData(false)]
+			public async Task WhenSubjectHasNoDefaultFieldConstructor_ShouldFailUnlessIncludeFieldsIsSet(
+				bool includeFields)
+			{
+				PocoWithoutDefaultFieldConstructor subject = new(12);
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<PocoWithoutDefaultFieldConstructor>(
+						new JsonSerializerOptions
+						{
+							IncludeFields = includeFields,
+						});
+
+				await That(Act).Throws<XunitException>().OnlyIf(!includeFields)
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as PocoWithoutDefaultFieldConstructor JSON,
+					             but it could not be deserialized: Each parameter in the deserialization constructor on type 'aweXpect.Json.Tests.ThatJsonObject+IsJsonSerializable+PocoWithoutDefaultFieldConstructor' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object. Fields are only considered when 'JsonSerializerOptions.IncludeFields' is enabled*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				object? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<SimplePocoWithPrimitiveTypes>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as SimplePocoWithPrimitiveTypes JSON,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeDoesNotMatch_ShouldFail()
+			{
+				SimplePocoWithPrimitiveTypes subject = new()
+				{
+					Id = 1,
+					GlobalId = Guid.NewGuid(),
+					Name = "foo",
+					DateOfBirth = DateTime.Today,
+					Height = new decimal(4.3),
+					Weight = 5.6,
+					ShoeSize = 7.8f,
+					IsActive = true,
+					Image = [8, 9, 10, 11,],
+					Category = 'a',
+				};
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<PocoWithIgnoredProperty>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is serializable as PocoWithIgnoredProperty JSON,
+					             but it was not assignable to PocoWithIgnoredProperty
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeMatches_ShouldSucceed()
+			{
+				SimplePocoWithPrimitiveTypes subject = new()
+				{
+					Id = 1,
+					GlobalId = Guid.NewGuid(),
+					Name = "foo",
+					DateOfBirth = DateTime.Today,
+					Height = new decimal(4.3),
+					Weight = 5.6,
+					ShoeSize = 7.8f,
+					IsActive = true,
+					Image = [8, 9, 10, 11,],
+					Category = 'a',
+				};
+
+				async Task Act()
+					=> await That(subject).IsJsonSerializable<SimplePocoWithPrimitiveTypes>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public class PocoWithoutDefaultConstructor(int value)
+		{
+			public int Id { get; } = value;
+		}
+
+		public class PocoWithIgnoredProperty
+		{
+			public int Id { get; set; }
+
+			[JsonIgnore] public string? Name { get; set; }
+		}
+
+		public class PocoWithoutDefaultFieldConstructor(int value)
+		{
+			public int Value = value;
+		}
+
+		public class PocoWithPrivateConstructor
+		{
+			private PocoWithPrivateConstructor() { }
+
+			public int Id { get; set; }
+
+			public static PocoWithPrivateConstructor Create(int id) => new()
+			{
+				Id = id,
+			};
+		}
+
+		public class PocoWithPrivateConstructorWithJsonConstructorAttribute
+		{
+			[JsonConstructor]
+			private PocoWithPrivateConstructorWithJsonConstructorAttribute() { }
+
+			public int Id { get; init; }
+
+			public static PocoWithPrivateConstructorWithJsonConstructorAttribute Create(int id) => new()
+			{
+				Id = id,
+			};
+		}
+
+		public class SimplePocoWithPrimitiveTypes
+		{
+			public int Id { get; set; }
+
+			public Guid GlobalId { get; set; }
+
+			public string Name { get; set; } = "";
+
+			public DateTime DateOfBirth { get; set; }
+
+			public decimal Height { get; set; }
+
+			public double Weight { get; set; }
+
+			public float ShoeSize { get; set; }
+
+			public bool IsActive { get; set; }
+
+			public byte[] Image { get; set; } = [];
+
+			public char Category { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
## Object serializable

You can verify that an object is JSON serializable:

```csharp
MyObject subject = new();

await Expect.That(subject).IsJsonSerializable();
```

This will try to serialize and deserialize the provided object and check that they are equivalent.

You can provide both JSON serialization and equivalency options:

```csharp
MyObject subject = new();

await Expect.That(subject).IsJsonSerializable(
    new JsonSerializerOptions
    {
        IncludeFields = includeFields,
    },
    o => o.IgnoringMember("MyPropertyToIgnore"));
```