### PR TITLE
chore: Add CI-Analysis Pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
                     dotnet-version: |
                         8.0.x
             -   name: Run mutation tests
-                run: ./build.sh MutationTests
+                run: ./build.sh MutationTests MutationTestDashboard
     
     benchmarks:
         name: "Benchmarks"

--- a/.github/workflows/ci-analysis.yml
+++ b/.github/workflows/ci-analysis.yml
@@ -1,0 +1,91 @@
+name: CI-Analysis
+
+on:
+    workflow_run:
+        workflows: [ "CI" ]
+        types:
+            - completed
+
+jobs:
+    mutation-tests:
+        name: "Mutation tests"
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        env:
+            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        steps:
+            - name: 'Download artifact'
+              uses: actions/github-script@v3.1.0
+              with:
+                  script: |
+                      var artifacts = await github.actions.listWorkflowRunArtifacts({
+                         owner: context.repo.owner,
+                         repo: context.repo.repo,
+                         run_id: ${{github.event.workflow_run.id }},
+                      });
+                      var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+                        return artifact.name == "MutationTests"
+                      })[0];
+                      var download = await github.actions.downloadArtifact({
+                         owner: context.repo.owner,
+                         repo: context.repo.repo,
+                         artifact_id: matchArtifact.id,
+                         archive_format: 'zip',
+                      });
+                      var fs = require('fs');
+                      fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
+            -   run: unzip artifacts.zip
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+            -   name: Run mutation tests
+                run: ./build.sh MutationTestDashboard
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+    
+    benchmarks:
+        name: "Benchmarks"
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: 'Download artifact'
+              uses: actions/github-script@v3.1.0
+              with:
+                  script: |
+                      var artifacts = await github.actions.listWorkflowRunArtifacts({
+                         owner: context.repo.owner,
+                         repo: context.repo.repo,
+                         run_id: ${{github.event.workflow_run.id }},
+                      });
+                      var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+                        return artifact.name == "Benchmarks"
+                      })[0];
+                      var download = await github.actions.downloadArtifact({
+                         owner: context.repo.owner,
+                         repo: context.repo.repo,
+                         artifact_id: matchArtifact.id,
+                         archive_format: 'zip',
+                      });
+                      var fs = require('fs');
+                      fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
+            -   run: unzip artifacts.zip
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+            -   name: Create benchmark comment
+                run: ./build.sh BenchmarkComment
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,8 @@ jobs:
 
     mutation-tests:
         name: "Mutation tests"
-        if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
-        permissions:
-            pull-requests: write
         env:
-            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
             DOTNET_NOLOGO: true
         steps:
             -   uses: actions/checkout@v4
@@ -81,16 +77,18 @@ jobs:
                         8.0.x
             -   name: Run mutation tests
                 run: ./build.sh MutationTests
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
-    
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: MutationTests
+                    path: |
+                        ./Artifacts/*
+
     benchmarks:
         name: "Benchmarks"
         if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -104,8 +102,13 @@ jobs:
                         8.0.x
             -   name: Run benchmarks
                 run: ./build.sh Benchmarks
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: Benchmarks
+                    path: |
+                        ./Artifacts/*
     
     static-code-analysis:
         name: "Static code analysis"

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -39,6 +39,7 @@
         "DotNetFrameworkUnitTests",
         "DotNetUnitTests",
         "MutationComment",
+        "MutationTestDashboard",
         "MutationTestExecution",
         "MutationTests",
         "Pack",

--- a/aweXpect.Json.sln
+++ b/aweXpect.Json.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\ci.yml = .github\workflows\ci.yml
+		.github\workflows\ci-analysis.yml = .github\workflows\ci-analysis.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{B776D4D9-F241-49BA-B005-8484BC686008}"


### PR DESCRIPTION
Add a `CI-Analysis` pipeline that uses the `workflow_run` trigger and executes the parts of the pipeline that require access to secrets.