### PR TITLE
feat: add negated expectations (1)

### DIFF
--- a/.idea/.idea.aweXpect.Json/.idea/.name
+++ b/.idea/.idea.aweXpect.Json/.idea/.name
@@ -1,1 +1,0 @@
-aweXpect.Json

--- a/Source/aweXpect.Json/Json/JsonValidation.cs
+++ b/Source/aweXpect.Json/Json/JsonValidation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using aweXpect.Core;
 
 namespace aweXpect.Json;
 
@@ -455,13 +456,18 @@ internal class JsonValidation : IJsonObjectResult,
 		return string.Join(failureSeparator, _failures);
 	}
 
-	internal static string Format(JsonValueKind valueKind)
-		=> valueKind switch
+	internal static string Format(JsonValueKind valueKind, ExpectationGrammars grammars = ExpectationGrammars.None)
+		=> (valueKind, grammars.IsNegated()) switch
 		{
-			JsonValueKind.Array => "an array",
-			JsonValueKind.Object => "an object",
-			JsonValueKind.Number => "a number",
-			JsonValueKind.String => "a string",
-			_ => valueKind.ToString().ToLower(),
+			(JsonValueKind.Array, false) => "an array",
+			(JsonValueKind.Object, false) => "an object",
+			(JsonValueKind.Number, false) => "a number",
+			(JsonValueKind.String, false) => "a string",
+			(_, false) => valueKind.ToString().ToLower(),
+			(JsonValueKind.Array, true) => "no array",
+			(JsonValueKind.Object, true) => "no object",
+			(JsonValueKind.Number, true) => "no number",
+			(JsonValueKind.String, true) => "no string",
+			(_, true) => $"not {valueKind.ToString().ToLower()}",
 		};
 }

--- a/Source/aweXpect.Json/JsonFormatting.cs
+++ b/Source/aweXpect.Json/JsonFormatting.cs
@@ -1,0 +1,46 @@
+﻿using System.Text;
+using System.Text.Json;
+
+namespace aweXpect;
+
+/// <summary>
+///     Formatting extensions for <see cref="JsonElement" />.
+/// </summary>
+public static class JsonFormatting
+{
+	/// <summary>
+	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	/// </summary>
+	public static string Format(
+		this ValueFormatter formatter,
+		JsonElement? value,
+		FormattingOptions? options = null)
+	{
+		if (value == null)
+		{
+			return ValueFormatter.NullString;
+		}
+
+		return JsonSerializer.Serialize(value);
+	}
+
+	/// <summary>
+	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     to the <paramref name="stringBuilder" />
+	/// </summary>
+	public static void Format(
+		this ValueFormatter formatter,
+		StringBuilder stringBuilder,
+		JsonElement? value,
+		FormattingOptions? options = null)
+	{
+		if (value == null)
+		{
+			stringBuilder.Append(ValueFormatter.NullString);
+		}
+		else
+		{
+			stringBuilder.Append(JsonSerializer.Serialize(value));
+		}
+	}
+}

--- a/Source/aweXpect.Json/ThatJsonElement.cs
+++ b/Source/aweXpect.Json/ThatJsonElement.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -51,7 +50,19 @@ public static partial class ThatJsonElement
 			=> stringBuilder.Append(it).Append(" differed as").Append(_comparisonResult);
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+		{
+			stringBuilder.Append("does not match ").Append(expectedExpression);
+			if (!options.IgnoreAdditionalProperties)
+			{
+				stringBuilder.Append(" exactly");
+			}
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" did match in ");
+			Formatter.Format(stringBuilder, Actual);
+		}
 	}
 
 
@@ -67,13 +78,16 @@ public static partial class ThatJsonElement
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is ").Append(JsonValidation.Format(expected));
+			=> stringBuilder.Append("is ").Append(JsonValidation.Format(expected, Grammars));
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 			=> stringBuilder.Append(it).Append(" was ").Append(JsonValidation.Format(Actual.ValueKind))
 				.Append(" instead of ").Append(JsonValidation.Format(expected));
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+			=> stringBuilder.Append("is ").Append(JsonValidation.Format(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(it).Append(" was");
 	}
 }

--- a/Source/aweXpect.Json/ThatNullableJsonElement.cs
+++ b/Source/aweXpect.Json/ThatNullableJsonElement.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -18,7 +17,7 @@ public static partial class ThatNullableJsonElement
 		object? expected,
 		string expectedExpression,
 		JsonOptions options)
-		: ConstraintResult.WithNotNullValue<JsonElement?>(it, grammars),
+		: ConstraintResult.WithValue<JsonElement?>(grammars),
 			IValueConstraint<JsonElement?>
 	{
 		private JsonElementValidator.JsonComparisonResult? _comparisonResult;
@@ -54,10 +53,30 @@ public static partial class ThatNullableJsonElement
 		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append(It).Append(" differed as").Append(_comparisonResult);
+		{
+			if (Actual == null)
+			{
+				stringBuilder.Append(it).Append(" was <null>");
+				return;
+			}
+
+			stringBuilder.Append(it).Append(" differed as").Append(_comparisonResult);
+		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+		{
+			stringBuilder.Append("does not match ").Append(expectedExpression);
+			if (!options.IgnoreAdditionalProperties)
+			{
+				stringBuilder.Append(" exactly");
+			}
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" did match in ");
+			Formatter.Format(stringBuilder, Actual);
+		}
 	}
 
 
@@ -73,13 +92,16 @@ public static partial class ThatNullableJsonElement
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is ").Append(JsonValidation.Format(expected));
+			=> stringBuilder.Append("is ").Append(JsonValidation.Format(expected, Grammars));
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 			=> stringBuilder.Append(It).Append(" was ").Append(JsonValidation.Format(Actual!.Value.ValueKind))
 				.Append(" instead of ").Append(JsonValidation.Format(expected));
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+			=> stringBuilder.Append("is ").Append(JsonValidation.Format(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" was");
 	}
 }

--- a/Tests/aweXpect.Json.Api.Tests/Expected/aweXpect.Json_net8.0.txt
+++ b/Tests/aweXpect.Json.Api.Tests/Expected/aweXpect.Json_net8.0.txt
@@ -70,6 +70,11 @@ namespace aweXpect
         public static TSelf AsJson<TType, TThat, TSelf>(this aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> result, System.Func<aweXpect.Json.JsonOptions, aweXpect.Json.JsonOptions>? options = null)
             where TSelf : aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> { }
     }
+    public static class JsonFormatting
+    {
+        public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.Text.Json.JsonElement? value, aweXpect.Formatting.FormattingOptions? options = null) { }
+        public static void Format(this aweXpect.Formatting.ValueFormatter formatter, System.Text.StringBuilder stringBuilder, System.Text.Json.JsonElement? value, aweXpect.Formatting.FormattingOptions? options = null) { }
+    }
     public static class ThatJsonElement
     {
         public static aweXpect.Results.AndOrResult<System.Text.Json.JsonElement, aweXpect.Core.IThat<System.Text.Json.JsonElement>> IsArray(this aweXpect.Core.IThat<System.Text.Json.JsonElement> source) { }

--- a/Tests/aweXpect.Json.Api.Tests/Expected/aweXpect.Json_netstandard2.0.txt
+++ b/Tests/aweXpect.Json.Api.Tests/Expected/aweXpect.Json_netstandard2.0.txt
@@ -70,6 +70,11 @@ namespace aweXpect
         public static TSelf AsJson<TType, TThat, TSelf>(this aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> result, System.Func<aweXpect.Json.JsonOptions, aweXpect.Json.JsonOptions>? options = null)
             where TSelf : aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> { }
     }
+    public static class JsonFormatting
+    {
+        public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.Text.Json.JsonElement? value, aweXpect.Formatting.FormattingOptions? options = null) { }
+        public static void Format(this aweXpect.Formatting.ValueFormatter formatter, System.Text.StringBuilder stringBuilder, System.Text.Json.JsonElement? value, aweXpect.Formatting.FormattingOptions? options = null) { }
+    }
     public static class ThatJsonElement
     {
         public static aweXpect.Results.AndOrResult<System.Text.Json.JsonElement, aweXpect.Core.IThat<System.Text.Json.JsonElement>> IsArray(this aweXpect.Core.IThat<System.Text.Json.JsonElement> source) { }

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.IsArray.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.IsArray.Tests.cs
@@ -8,6 +8,76 @@ public sealed partial class ThatJsonElement
 	{
 		public sealed class Tests
 		{
+			[Theory]
+			[InlineData("[]")]
+			[InlineData("[1, 2]")]
+			public async Task WhenJsonIsAnArray_ShouldSucceed(string json)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("{}", "an object")]
+			[InlineData("2", "a number")]
+			[InlineData("\"foo\"", "a string")]
+			public async Task WhenJsonIsNoArray_ShouldFail(string json, string kindString)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is an array,
+					              but it was {kindString} instead of an array
+					              """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("[]")]
+			[InlineData("[1, 2]")]
+			public async Task WhenJsonIsAnArray_ShouldFail(string json)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsArray());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is no array,
+					             but it was
+					             """);
+			}
+
+			[Theory]
+			[InlineData("{}")]
+			[InlineData("2")]
+			[InlineData("\"foo\"")]
+			public async Task WhenJsonIsNoArray_ShouldSucceed(string json)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsArray());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class ExpectationTests
+		{
 			[Fact]
 			public async Task IsArray_ShouldBeChainable()
 			{
@@ -115,38 +185,6 @@ public sealed partial class ThatJsonElement
 					              Expected that subject
 					              is an object and $.foo is an array,
 					              but it differed as $.foo was {kindString} instead of an array
-					              """);
-			}
-
-			[Theory]
-			[InlineData("[]")]
-			[InlineData("[1, 2]")]
-			public async Task WhenJsonIsAnArray_ShouldSucceed(string json)
-			{
-				JsonElement subject = FromString(json);
-
-				async Task Act()
-					=> await That(subject).IsArray();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Theory]
-			[InlineData("{}", "an object")]
-			[InlineData("2", "a number")]
-			[InlineData("\"foo\"", "a string")]
-			public async Task WhenJsonIsNoArray_ShouldFail(string json, string kindString)
-			{
-				JsonElement subject = FromString(json);
-
-				async Task Act()
-					=> await That(subject).IsArray();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              is an array,
-					              but it was {kindString} instead of an array
 					              """);
 			}
 

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.IsObject.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.IsObject.Tests.cs
@@ -60,6 +60,41 @@ public sealed partial class ThatJsonElement
 			}
 		}
 
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("{}")]
+			[InlineData("{\"foo\": 1}")]
+			public async Task WhenJsonIsAnObject_ShouldFail(string json)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsObject());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is no object,
+					             but it was
+					             """);
+			}
+
+			[Theory]
+			[InlineData("[]")]
+			[InlineData("2")]
+			[InlineData("\"foo\"")]
+			public async Task WhenJsonIsNoObject_ShouldSucceed(string json)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsObject());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class WithTests
 		{
 			[Fact]

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.Matches.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.Matches.Tests.cs
@@ -101,6 +101,101 @@ public sealed partial class ThatJsonElement
 			}
 		}
 
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("true", true, true)]
+			[InlineData("true", false, false)]
+			[InlineData("false", true, false)]
+			[InlineData("false", false, true)]
+			public async Task BooleanValue_ShouldFailWhenMatching(string json, bool expected, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("42.1", 42.1, true)]
+			[InlineData("1.2", 2.1, false)]
+			public async Task DoubleValue_ShouldFailWhenMatching(string json, double expected, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("42", 42, true)]
+			[InlineData("1", 2, false)]
+			public async Task IntegerValue_ShouldFailWhenMatching(string json, int expected, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("null", true)]
+			[InlineData("{}", false)]
+			public async Task NullValue_ShouldFailWhenMatching(string json, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(null));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match null,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("\"foo\"", "foo", true)]
+			[InlineData("\"foo\"", "bar", false)]
+			public async Task StringValue_ShouldFailWhenMatching(string json, string expected, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected,
+					              but it did match in {json}
+					              """);
+			}
+		}
+
 		public sealed class ArrayTests
 		{
 			[Theory]

--- a/Tests/aweXpect.Json.Tests/ThatJsonElement.MatchesExactly.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatJsonElement.MatchesExactly.Tests.cs
@@ -101,6 +101,101 @@ public sealed partial class ThatJsonElement
 			}
 		}
 
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("true", true, true)]
+			[InlineData("true", false, false)]
+			[InlineData("false", true, false)]
+			[InlineData("false", false, true)]
+			public async Task BooleanValue_ShouldFailWhenMatching(string json, bool expected, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected exactly,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("42.1", 42.1, true)]
+			[InlineData("1.2", 2.1, false)]
+			public async Task DoubleValue_ShouldFailWhenMatching(string json, double expected, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected exactly,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("42", 42, true)]
+			[InlineData("1", 2, false)]
+			public async Task IntegerValue_ShouldFailWhenMatching(string json, int expected, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected exactly,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("null", true)]
+			[InlineData("{}", false)]
+			public async Task NullValue_ShouldFailWhenMatching(string json, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(null));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match null exactly,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("\"foo\"", "foo", true)]
+			[InlineData("\"foo\"", "bar", false)]
+			public async Task StringValue_ShouldFailWhenMatching(string json, string expected, bool isMatch)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected exactly,
+					              but it did match in {json}
+					              """);
+			}
+		}
+
 		public sealed class ArrayTests
 		{
 			[Theory]

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.IsArray.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.IsArray.Tests.cs
@@ -9,6 +9,92 @@ public sealed partial class ThatNullableJsonElement
 		public sealed class Tests
 		{
 			[Theory]
+			[InlineData("[]")]
+			[InlineData("[1, 2]")]
+			public async Task WhenJsonIsAnArray_ShouldSucceed(string json)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("{}", "an object")]
+			[InlineData("2", "a number")]
+			[InlineData("\"foo\"", "a string")]
+			public async Task WhenJsonIsNoArray_ShouldFail(string json, string kindString)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is an array,
+					              but it was {kindString} instead of an array
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				JsonElement? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an array,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("[]")]
+			[InlineData("[1, 2]")]
+			public async Task WhenJsonIsAnArray_ShouldFail(string json)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsArray());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is no array,
+					             but it was
+					             """);
+			}
+
+			[Theory]
+			[InlineData("{}")]
+			[InlineData("2")]
+			[InlineData("\"foo\"")]
+			public async Task WhenJsonIsNoArray_ShouldSucceed(string json)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsArray());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class WithExpectationTests
+		{
+			[Theory]
 			[InlineData("{\"foo\":{}}", "an object")]
 			[InlineData("{\"foo\":2}", "a number")]
 			[InlineData("{\"foo\":\"foo\"}", "a string")]
@@ -66,38 +152,6 @@ public sealed partial class ThatNullableJsonElement
 			}
 
 			[Theory]
-			[InlineData("[]")]
-			[InlineData("[1, 2]")]
-			public async Task WhenJsonIsAnArray_ShouldSucceed(string json)
-			{
-				JsonElement? subject = FromString(json);
-
-				async Task Act()
-					=> await That(subject).IsArray();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Theory]
-			[InlineData("{}", "an object")]
-			[InlineData("2", "a number")]
-			[InlineData("\"foo\"", "a string")]
-			public async Task WhenJsonIsNoArray_ShouldFail(string json, string kindString)
-			{
-				JsonElement? subject = FromString(json);
-
-				async Task Act()
-					=> await That(subject).IsArray();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              is an array,
-					              but it was {kindString} instead of an array
-					              """);
-			}
-
-			[Theory]
 			[InlineData(true)]
 			[InlineData(false)]
 			public async Task WhenJsonIsNoArray_WithExpectations_ShouldConsiderIgnoreAdditionalProperties(
@@ -143,22 +197,6 @@ public sealed partial class ThatNullableJsonElement
 					              is an array and $[0] matches true,
 					              but it was {kindString} instead of an array
 					              """);
-			}
-
-			[Fact]
-			public async Task WhenSubjectIsNull_ShouldFail()
-			{
-				JsonElement? subject = null;
-
-				async Task Act()
-					=> await That(subject).IsArray();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             is an array,
-					             but it was <null>
-					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.IsObject.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.IsObject.Tests.cs
@@ -94,6 +94,41 @@ public sealed partial class ThatNullableJsonElement
 			}
 		}
 
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("{}")]
+			[InlineData("{\"foo\": 1}")]
+			public async Task WhenJsonIsAnObject_ShouldFail(string json)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsObject());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is no object,
+					             but it was
+					             """);
+			}
+
+			[Theory]
+			[InlineData("[]")]
+			[InlineData("2")]
+			[InlineData("\"foo\"")]
+			public async Task WhenJsonIsNoObject_ShouldSucceed(string json)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsObject());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class WithTests
 		{
 			[Fact]

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.Matches.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.Matches.Tests.cs
@@ -117,6 +117,113 @@ public sealed partial class ThatNullableJsonElement
 			}
 		}
 
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("true", true, true)]
+			[InlineData("true", false, false)]
+			[InlineData("false", true, false)]
+			[InlineData("false", false, true)]
+			public async Task BooleanValue_ShouldFailWhenMatching(string json, bool expected, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("42.1", 42.1, true)]
+			[InlineData("1.2", 2.1, false)]
+			public async Task DoubleValue_ShouldFailWhenMatching(string json, double expected, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("42", 42, true)]
+			[InlineData("1", 2, false)]
+			public async Task IntegerValue_ShouldFailWhenMatching(string json, int expected, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("null", true)]
+			[InlineData("{}", false)]
+			public async Task NullValue_ShouldFailWhenMatching(string json, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(null));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match null,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("\"foo\"", "foo", true)]
+			[InlineData("\"foo\"", "bar", false)]
+			public async Task StringValue_ShouldFailWhenMatching(string json, string expected, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.Matches(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldSucceed()
+			{
+				JsonElement? subject = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.Matches(new object(), o => o.IgnoringAdditionalProperties()));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class ArrayTests
 		{
 			[Theory]

--- a/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.MatchesExactly.Tests.cs
+++ b/Tests/aweXpect.Json.Tests/ThatNullableJsonElement.MatchesExactly.Tests.cs
@@ -117,6 +117,101 @@ public sealed partial class ThatNullableJsonElement
 			}
 		}
 
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("true", true, true)]
+			[InlineData("true", false, false)]
+			[InlineData("false", true, false)]
+			[InlineData("false", false, true)]
+			public async Task BooleanValue_ShouldFailWhenMatching(string json, bool expected, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected exactly,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("42.1", 42.1, true)]
+			[InlineData("1.2", 2.1, false)]
+			public async Task DoubleValue_ShouldFailWhenMatching(string json, double expected, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected exactly,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("42", 42, true)]
+			[InlineData("1", 2, false)]
+			public async Task IntegerValue_ShouldFailWhenMatching(string json, int expected, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected exactly,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("null", true)]
+			[InlineData("{}", false)]
+			public async Task NullValue_ShouldFailWhenMatching(string json, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(null));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match null exactly,
+					              but it did match in {json}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("\"foo\"", "foo", true)]
+			[InlineData("\"foo\"", "bar", false)]
+			public async Task StringValue_ShouldFailWhenMatching(string json, string expected, bool isMatch)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.MatchesExactly(expected));
+
+				await That(Act).Throws<XunitException>().OnlyIf(isMatch)
+					.WithMessage($"""
+					              Expected that subject
+					              does not match expected exactly,
+					              but it did match in {json}
+					              """);
+			}
+		}
+
 		public sealed class ArrayTests
 		{
 			[Theory]


### PR DESCRIPTION
- Add Formatter for `JsonElement`

- Support `DoesNotComplyWith` for the following expectation constraints in aweXpect.Json:
  - `IsValueKindConstraint`
  - `IsJsonSerializableConstraint`
  - `MatchesConstraint`