### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.22.0"/>
+		<PackageVersion Include="aweXpect" Version="2.23.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="2.21.1"/>
 		<PackageVersion Include="System.Text.Json" Version="9.0.2"/>
 	</ItemGroup>


### PR DESCRIPTION
This PR bumps the aweXpect package version from 2.22.0 to 2.23.0 in the centralized package management configuration.

### Key changes:
- Updates aweXpect package version to 2.23.0