### PR TITLE
docs: move nuget badge in documentation on separate line

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,4 +1,6 @@
-# [aweXpect.Json](https://github.com/aweXpect/aweXpect.Json) [![Nuget](https://img.shields.io/nuget/v/aweXpect.Json)](https://www.nuget.org/packages/aweXpect.Json)
+# [aweXpect.Json](https://github.com/aweXpect/aweXpect.Json)
+
+[![Nuget](https://img.shields.io/nuget/v/aweXpect.Json)](https://www.nuget.org/packages/aweXpect.Json)
 
 Expectations for the `System.Text.Json` namespace.
 


### PR DESCRIPTION
Move the NuGet badge from the same line as the main heading to a separate line in the documentation index page for better formatting and readability.