### PR TITLE
docs: avoid link in headline

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,7 +1,7 @@
-# [aweXpect.Json](https://github.com/aweXpect/aweXpect.Json)
+# aweXpect.Json
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Json)](https://www.nuget.org/packages/aweXpect.Json)
 
-Expectations for the `System.Text.Json` namespace.
+[aweXpect.Json](https://github.com/aweXpect/aweXpect.Json) contains expectations for the `System.Text.Json` namespace.
 
 {README}


### PR DESCRIPTION
This PR removes a link from the main headline and relocates it to the description text to improve document formatting.