### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.26.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="2.24.0"/>
+		<PackageVersion Include="aweXpect" Version="2.27.1"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.25.1"/>
 		<PackageVersion Include="System.Text.Json" Version="9.0.2"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Source/aweXpect.Json/Json/JsonMatchType.cs
+++ b/Source/aweXpect.Json/Json/JsonMatchType.cs
@@ -44,7 +44,7 @@ internal sealed class JsonMatchType(JsonOptions options) : IStringMatchType
 			string? actual,
 			string? expected,
 			bool ignoreCase,
-			IEqualityComparer<string> comparer)
+			IEqualityComparer<string>? comparer)
 	{
 		if (actual == null && expected == null)
 		{


### PR DESCRIPTION
Bump aweXpect dependencies to newer versions for centralized package management.
- Update aweXpect from 2.24.0 to 2.27.0
- Update aweXpect.Core from 2.22.2 to 2.25.1