### PR TITLE
chore: align remaining aweXpect references in README and pipeline

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -167,7 +167,7 @@ partial class Build
 					Credentials tokenAuth = new(GithubToken);
 					gitHubClient.Credentials = tokenAuth;
 					IReadOnlyList<IssueComment> comments =
-						await gitHubClient.Issue.Comment.GetAllForIssue("aweXpect", "aweXpect.Json", prId);
+						await gitHubClient.Issue.Comment.GetAllForIssue("Testably", "aweXpect.Json", prId);
 					long? commentId = null;
 					Log.Information($"Found {comments.Count} comments");
 					foreach (IssueComment comment in comments)
@@ -182,12 +182,12 @@ partial class Build
 					if (commentId == null)
 					{
 						Log.Information($"Create comment:\n{body}");
-						await gitHubClient.Issue.Comment.Create("aweXpect", "aweXpect.Json", prId, body);
+						await gitHubClient.Issue.Comment.Create("Testably", "aweXpect.Json", prId, body);
 					}
 					else
 					{
 						Log.Information($"Update comment:\n{body}");
-						await gitHubClient.Issue.Comment.Update("aweXpect", "aweXpect.Json", commentId.Value, body);
+						await gitHubClient.Issue.Comment.Update("Testably", "aweXpect.Json", commentId.Value, body);
 					}
 				}
 			}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # aweXpect.Json
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Json)](https://www.nuget.org/packages/aweXpect.Json)
-[![Build](https://github.com/aweXpect/aweXpect.Json/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Json/actions/workflows/build.yml)
+[![Build](https://github.com/Testably/aweXpect.Json/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/aweXpect.Json/actions/workflows/build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Json&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect.Json)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Json&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_aweXpect.Json)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect.Json%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Json/main)


### PR DESCRIPTION
Follow-up to the SonarCloud and Stryker organization moves: updates the GitHub Build badge in the README and the Octokit calls in MutationTestDashboard so they target the Testably owner instead of relying on the GitHub redirect from aweXpect.